### PR TITLE
Chat endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,2 @@
+# CHAT.CONNOR.FUN API
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The repository must be placed at `$GOPATH/src/github.com/aaronaaeng/chat.connor.
 - `github.com/dgrijalva/jwt-go`
 - `github.com/labstack/echo`
 - `github.com/lib/pq`
+- `github.com/gorilla/websocket`
 
 ### Running 
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The repository must be placed at `$GOPATH/src/github.com/aaronaaeng/chat.connor.
 - `github.com/labstack/echo`
 - `github.com/lib/pq`
 - `github.com/gorilla/websocket`
+- `github.com/posener/wstest`
 
 ### Running 
 

--- a/assets/roles.json
+++ b/assets/roles.json
@@ -14,6 +14,7 @@
     "override": "NONE",
     "permissions": [
       {"path": "/", "verbs": "r"},
+      {"path": "/wstest", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
       {"path": "/api/v1/rooms/*/messages/ws",   "verbs": "r"},
@@ -26,6 +27,7 @@
     "override": "NONE",
     "permissions": [
       {"path": "/", "verbs": "r"},
+      {"path": "/wstest", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
       {"path": "/api/v1/rooms/*/messages/ws",   "verbs": "cr"},

--- a/assets/roles.json
+++ b/assets/roles.json
@@ -16,7 +16,7 @@
       {"path": "/", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
-      {"path": "/api/v1/room/*/messages",   "verbs": "r"},
+      {"path": "/api/v1/room/*/messages/ws",   "verbs": "r"},
       {"path": "/api/v1/room/*/messages/*", "verbs": "r"}
     ]
   },
@@ -28,7 +28,7 @@
       {"path": "/", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
-      {"path": "/api/v1/room/*/messages",   "verbs": "cr"},
+      {"path": "/api/v1/room/*/messages/ws",   "verbs": "cr"},
       {"path": "/api/v1/room/*/messages/*", "verbs": "r"}
     ]
   }

--- a/assets/roles.json
+++ b/assets/roles.json
@@ -16,8 +16,8 @@
       {"path": "/", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
-      {"path": "/api/v1/room/*/messages/ws",   "verbs": "r"},
-      {"path": "/api/v1/room/*/messages/*", "verbs": "r"}
+      {"path": "/api/v1/rooms/*/messages/ws",   "verbs": "r"},
+      {"path": "/api/v1/rooms/*/messages/*", "verbs": "r"}
     ]
   },
 
@@ -28,8 +28,8 @@
       {"path": "/", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
-      {"path": "/api/v1/room/*/messages/ws",   "verbs": "cr"},
-      {"path": "/api/v1/room/*/messages/*", "verbs": "r"}
+      {"path": "/api/v1/rooms/*/messages/ws",   "verbs": "cr"},
+      {"path": "/api/v1/rooms/*/messages/*", "verbs": "r"}
     ]
   }
 }

--- a/assets/roles.json
+++ b/assets/roles.json
@@ -17,7 +17,7 @@
       {"path": "/wstest", "verbs": "r"},
       {"path": "/api/v1/users",  "verbs": "c"},
       {"path": "/api/v1/login", "verbs": "c"},
-      {"path": "/api/v1/rooms/*/messages/ws",   "verbs": "r"},
+      {"path": "/api/v1/rooms/*/messages/ws",   "verbs": "cr"},
       {"path": "/api/v1/rooms/*/messages/*", "verbs": "r"}
     ]
   },

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,14 @@
+package context
+
+
+import (
+	"github.com/labstack/echo"
+	"github.com/aaronaaeng/chat.connor.fun/model"
+)
+
+type AuthorizedContext struct {
+	echo.Context
+	JwtString string
+	Requestor *model.User
+	Code model.AccessCode
+}

--- a/context/context.go
+++ b/context/context.go
@@ -6,9 +6,47 @@ import (
 	"github.com/aaronaaeng/chat.connor.fun/model"
 )
 
-type AuthorizedContext struct {
+
+type AuthorizedContext interface {
 	echo.Context
-	JwtString string
-	Requestor *model.User
-	Code model.AccessCode
+
+	GetAccessCode() model.AccessCode
+	SetAccessCode(code model.AccessCode)
+
+	GetRequestor() *model.User
+	SetRequestor(user *model.User)
+
+	GetJWTString() string
+	SetJWTString(string string)
+}
+
+type AuthorizedContextImpl struct {
+	jwtString string
+	requestor *model.User
+	code model.AccessCode
+	echo.Context
+}
+
+func (c *AuthorizedContextImpl) GetAccessCode() model.AccessCode {
+	return c.code
+}
+
+func (c *AuthorizedContextImpl) GetRequestor() *model.User {
+	return c.requestor
+}
+
+func (c *AuthorizedContextImpl) GetJWTString() string {
+	return c.jwtString
+}
+
+func (c *AuthorizedContextImpl) SetAccessCode(code model.AccessCode) {
+	c.code = code
+}
+
+func (c *AuthorizedContextImpl) SetRequestor(user *model.User) {
+	c.requestor = user
+}
+
+func (c *AuthorizedContextImpl) SetJWTString(jwtString string) {
+	c.jwtString = jwtString
 }

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/labstack/gommon/log"
 	"github.com/aaronaaeng/chat.connor.fun/model"
 	"encoding/json"
-	"errors"
+	_"errors"
 )
 
 
@@ -36,7 +36,7 @@ func (c *Client) signMessage(messageBytes []byte) (*model.ChatMessage, error) {
 	if c.user != nil {
 		message.Creator = model.User{Id: c.user.Id, Username: c.user.Username}
 	} else {
-		return nil, errors.New("message has no creator")
+		//return nil, errors.New("message has no creator")
 	}
 	return &message, nil
 }

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -7,3 +7,5 @@ type Client struct {
 	conn *websocket.Conn
 	send chan []byte
 }
+
+

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -1,11 +1,19 @@
 package chat
 
-import "golang.org/x/net/websocket"
+import "github.com/gorilla/websocket"
 
 type Client struct {
-	room *Room
+	hub *Hub
 	conn *websocket.Conn
 	send chan []byte
 }
 
+
+func (c *Client) writer() {
+
+}
+
+func (c *Client) reader() {
+
+}
 

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -26,11 +26,6 @@ type Client struct {
 	send chan *model.ChatMessage
 }
 
-var (
-	newline = []byte{'\n'}
-	space   = []byte{' '}
-)
-
 func (c *Client) signMessage(messageBytes []byte) (*model.ChatMessage, error) {
 	var message model.ChatMessage
 	err := json.Unmarshal(messageBytes, &message)

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -1,6 +1,20 @@
 package chat
 
-import "github.com/gorilla/websocket"
+import (
+	"github.com/gorilla/websocket"
+	"time"
+	"github.com/labstack/gommon/log"
+	"bytes"
+)
+
+
+const (
+	writeWait = 5 * time.Second
+	pongWait = 60 * time.Second
+	pingPeriod = (pongWait * 9) / 10
+	maxMessageSize = 512
+)
+
 
 type Client struct {
 	hub *Hub
@@ -8,12 +22,78 @@ type Client struct {
 	send chan []byte
 }
 
+var (
+	newline = []byte{'\n'}
+	space   = []byte{' '}
+)
 
 func (c *Client) writer() {
-
+	defer func() {
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait)); return nil
+	})
+	for {
+		_, message, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
+				log.Printf("error: %v", err)
+			}
+			return
+		}
+		message = bytes.TrimSpace(bytes.Replace(message, newline, space, -1)) //Don't know why I do this... def didn't copy this line of code
+		c.hub.broadcast <- message //eventually we need to process the message
+	}
 }
 
 func (c *Client) reader() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
 
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok { //send channel is closed
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// The hub closed the channel.
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return
+			}
+			w.Write(message)
+
+			// Add queued chat messages to the current websocket message.
+			n := len(c.send)
+			for i := 0; i < n; i++ {
+				w.Write(newline)
+				w.Write(<-c.send)
+			}
+
+			if err := w.Close(); err != nil {
+				return
+			}
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
 }
 

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -1,0 +1,9 @@
+package chat
+
+import "golang.org/x/net/websocket"
+
+type Client struct {
+	room *Room
+	conn *websocket.Conn
+	send chan []byte
+}

--- a/controllers/chat/client.go
+++ b/controllers/chat/client.go
@@ -63,9 +63,12 @@ func (c *Client) writer() {
 			signedMessage, err := c.signMessage(message)
 			if err != nil {
 				log.Printf("error signing message: %v", err)
+				return //client sent invalid message, kick
 			} else {
 				c.hub.broadcast <- signedMessage //eventually we need to process the message
 			}
+		} else {
+			return //client isn't allowed to send, kick
 		}
 	}
 }

--- a/controllers/chat/hub.go
+++ b/controllers/chat/hub.go
@@ -1,7 +1,11 @@
 package chat
 
+import (
+	"sync"
+	"github.com/aaronaaeng/chat.connor.fun/model"
+)
 
-type Room struct {
+type Hub struct {
 	clients map[*Client]bool
 
 	broadcast chan []byte
@@ -12,9 +16,22 @@ type Room struct {
 	stop chan bool
 }
 
+type HubMap struct {
+	data sync.Map
+}
 
-func NewRoom() *Room {
-	return &Room{
+func (rm *HubMap) Store(roomName string, hub *Hub) {
+	rm.data.Store(roomName, hub)
+}
+
+func (rm *HubMap) Load(roomName string) (value *Hub, ok bool) {
+	res, ok := rm.data.Load(roomName)
+	return res.(*Hub), ok
+}
+
+
+func NewHub() *Hub {
+	return &Hub{
 		clients: make(map[*Client]bool),
 		broadcast: make(chan []byte),
 		register: make(chan *Client),
@@ -23,7 +40,7 @@ func NewRoom() *Room {
 	}
 }
 
-func (r *Room) runRoom() {
+func (r *Hub) runRoom() {
 	for {
 		select {
 			case client := <- r.register:

--- a/controllers/chat/hub.go
+++ b/controllers/chat/hub.go
@@ -2,12 +2,13 @@ package chat
 
 import (
 	"sync"
+	"github.com/aaronaaeng/chat.connor.fun/model"
 )
 
 type Hub struct {
 	clients map[*Client]bool
 
-	broadcast chan []byte
+	broadcast chan *model.ChatMessage
 
 	register chan *Client
 	unregister chan *Client
@@ -37,7 +38,7 @@ func (rm *HubMap) Delete(roomName string) {
 func NewHub() *Hub {
 	return &Hub{
 		clients: make(map[*Client]bool),
-		broadcast: make(chan []byte),
+		broadcast: make(chan *model.ChatMessage),
 		register: make(chan *Client),
 		unregister: make(chan *Client),
 		stop: make(chan bool),

--- a/controllers/chat/hub.go
+++ b/controllers/chat/hub.go
@@ -32,7 +32,10 @@ func (rm *HubMap) Store(roomName string, hub *Hub) {
 
 func (rm *HubMap) Load(roomName string) (value *Hub, ok bool) {
 	res, ok := rm.data.Load(roomName)
-	return res.(*Hub), ok
+	if ok {
+		return res.(*Hub), ok
+	}
+	return nil, ok
 }
 
 func (rm *HubMap) Delete(roomName string) {

--- a/controllers/chat/hub.go
+++ b/controllers/chat/hub.go
@@ -22,6 +22,10 @@ type HubMap struct {
 	data sync.Map
 }
 
+func NewHubMap() *HubMap {
+	return &HubMap{}
+}
+
 func (rm *HubMap) Store(roomName string, hub *Hub) {
 	rm.data.Store(roomName, hub)
 }

--- a/controllers/chat/room.go
+++ b/controllers/chat/room.go
@@ -1,0 +1,48 @@
+package chat
+
+
+type Room struct {
+	clients map[*Client]bool
+
+	broadcast chan []byte
+
+	register chan *Client
+	unregister chan *Client
+
+	stop chan bool
+}
+
+
+func NewRoom() *Room {
+	return &Room{
+		clients: make(map[*Client]bool),
+		broadcast: make(chan []byte),
+		register: make(chan *Client),
+		unregister: make(chan *Client),
+		stop: make(chan bool),
+	}
+}
+
+func (r *Room) runRoom() {
+	for {
+		select {
+			case client := <- r.register:
+				r.clients[client] = true
+			case client := <- r.unregister:
+				if _, ok := r.clients[client]; ok {
+					delete(r.clients, client)
+					close(client.send)
+				}
+			case message := <- r.broadcast:
+				for client := range r.clients {
+					select {
+						case client.send <- message:
+						default: //failed to send, close the client
+							close(client.send)
+							delete(r.clients, client)
+					}
+
+				}
+		}
+	}
+}

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -26,7 +26,7 @@ func isOriginValid(origin string, host string) bool {
 	return expected == origin
 }
 
-func HandleWebsocket(hubs *HubMap, c echo.Context) error {
+func HandleWebsocket(hubs *HubMap, allowWrite bool, c echo.Context) error {
 	if !isOriginValid(c.Request().Header.Get("Origin"), c.Request().Host) {
 		return c.NoContent(http.StatusForbidden)
 	}
@@ -49,7 +49,7 @@ func HandleWebsocket(hubs *HubMap, c echo.Context) error {
 		return err //upgrade failed
 	}
 
-	client := &Client{hub: hub, conn: conn, send: make(chan *model.ChatMessage)}
+	client := &Client{hub: hub, canWrite: allowWrite, conn: conn, send: make(chan *model.ChatMessage)}
 	client.hub.register <- client
 
 	go client.writer()

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -27,7 +27,7 @@ func isOriginValid(origin string, host string) bool {
 }
 
 func HandleWebsocket(hubs *HubMap, allowWrite bool, c echo.Context) error {
-	if !isOriginValid(c.Request().Header.Get("Origin"), c.Request().Host) {
+	if !config.Debug && !isOriginValid(c.Request().Header.Get("Origin"), c.Request().Host) {
 		return c.NoContent(http.StatusForbidden)
 	}
 

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -69,6 +69,7 @@ func lookupHub(name string, hubs *HubMap) (*Hub, error) {
 			return nil, nil
 		}
 		hub = NewHub() //init a new hub to activate the room
+		//TODO: run the hub
 		hubs.Store(name, hub)
 	}
 	return hub, nil

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gorilla/websocket"
 	"log"
 	"github.com/aaronaaeng/chat.connor.fun/config"
-	"github.com/aaronaaeng/chat.connor.fun/db/rooms"
+	_"github.com/aaronaaeng/chat.connor.fun/db/rooms"
 	"github.com/aaronaaeng/chat.connor.fun/model"
 )
 
@@ -61,15 +61,15 @@ func HandleWebsocket(hubs *HubMap, allowWrite bool, c echo.Context) error {
 func lookupHub(name string, hubs *HubMap) (*Hub, error) {
 	hub, ok := hubs.Load(name)
 	if !ok { //hub not in memory, check the database
-		room, err := rooms.Repo.GetByName(name)
-		if err != nil {
-			return nil, err
-		}
-		if room == nil { //room does not exist
-			return nil, nil
-		}
+		//room, err := rooms.Repo.GetByName(name)
+		//if err != nil {
+		//	return nil, err
+		//}
+		//if room == nil { //room does not exist
+		//	return nil, nil
+		//}
 		hub = NewHub() //init a new hub to activate the room
-		//TODO: run the hub
+		go hub.runRoom(nil)
 		hubs.Store(name, hub)
 	}
 	return hub, nil

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gorilla/websocket"
 	"log"
 	"github.com/aaronaaeng/chat.connor.fun/config"
-	"github.com/slimsag/godocmd/testdata"
 )
 
 

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -3,11 +3,11 @@ package chat
 import (
 	"github.com/labstack/echo"
 	"net/http"
-
 	"github.com/gorilla/websocket"
 	"log"
 	"github.com/aaronaaeng/chat.connor.fun/config"
 	"github.com/aaronaaeng/chat.connor.fun/db/rooms"
+	"github.com/aaronaaeng/chat.connor.fun/model"
 )
 
 
@@ -49,7 +49,7 @@ func HandleWebsocket(hubs *HubMap, c echo.Context) error {
 		return err //upgrade failed
 	}
 
-	client := &Client{hub: hub, conn: conn, send: make(chan []byte)}
+	client := &Client{hub: hub, conn: conn, send: make(chan *model.ChatMessage)}
 	client.hub.register <- client
 
 	go client.writer()

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gorilla/websocket"
 	"log"
 	"github.com/aaronaaeng/chat.connor.fun/config"
-	"github.com/slimsag/godocmd/testdata"
 	"github.com/aaronaaeng/chat.connor.fun/db/rooms"
 )
 

--- a/controllers/chat/websocket_controller.go
+++ b/controllers/chat/websocket_controller.go
@@ -1,0 +1,39 @@
+package chat
+
+import (
+	"github.com/labstack/echo"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"log"
+	"github.com/aaronaaeng/chat.connor.fun/config"
+	"github.com/slimsag/godocmd/testdata"
+)
+
+
+var upgrader = websocket.Upgrader{
+	WriteBufferSize: 1024,
+	ReadBufferSize: 1024,
+}
+
+func isOriginValid(origin string, host string) bool {
+	var expected string
+	if config.Debug {
+		expected = "http://" + host
+	} else {
+		expected = "https://" + host
+	}
+	return expected == origin
+}
+
+func HandleWebsocket(c echo.Context) {
+	if !isOriginValid(c.Request().Header.Get("Origin"), c.Request().Host) {
+		c.NoContent(http.StatusForbidden)
+	}
+	conn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		log.Println(err)
+		c.NoContent(http.StatusBadRequest)
+	}
+	//TODO: Need a way to store the different rooms without race conditions or bottlenecking
+}

--- a/controllers/chat/websocket_controller_test.go
+++ b/controllers/chat/websocket_controller_test.go
@@ -69,7 +69,7 @@ func TestHandleWebsocket_UpgradeWS(t *testing.T) {
 
 	s := httptest.NewServer(&handler)
 
-	d := wstest.NewDialer(&handler, t.Log)
+	d := wstest.NewDialer(&handler, nil)
 
 	conn, resp, err := d.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
 	assert.NoError(t, err)
@@ -100,8 +100,8 @@ func TestHandleWebsocket_MultipleClients(t *testing.T) {
 
 	s := httptest.NewServer(&handler)
 
-	dClient1 := wstest.NewDialer(&handler, t.Log)
-	dClient2 := wstest.NewDialer(&handler, t.Log)
+	dClient1 := wstest.NewDialer(&handler, nil)
+	dClient2 := wstest.NewDialer(&handler, nil)
 
 	client1Conn, resp, err := dClient1.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
 	assert.NoError(t, err)
@@ -154,7 +154,7 @@ func TestHandleWebsocket_IllegalMessage(t *testing.T) {
 
 	s := httptest.NewServer(&handler)
 
-	d := wstest.NewDialer(&handler, t.Log)
+	d := wstest.NewDialer(&handler, nil)
 
 	conn, resp, err := d.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
 	assert.NoError(t, err)
@@ -188,7 +188,7 @@ func TestHandleWebsocket_ReadOnly(t *testing.T) {
 
 	s := httptest.NewServer(&handler)
 
-	d := wstest.NewDialer(&handler, t.Log)
+	d := wstest.NewDialer(&handler, nil)
 
 	conn, resp, err := d.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
 	assert.NoError(t, err)

--- a/controllers/chat/websocket_controller_test.go
+++ b/controllers/chat/websocket_controller_test.go
@@ -26,10 +26,10 @@ func newTestHandler(e *echo.Echo, handler echo.HandlerFunc, code model.AccessCod
 }
 
 func (t *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	c := context.AuthorizedContext{
+	c := &context.AuthorizedContextImpl{
 		Context: t.e.NewContext(r, w),
-		Code: t.code,
 	}
+	c.SetAccessCode(t.code)
 	t.err = t.handler(c)
 }
 

--- a/controllers/chat/websocket_controller_test.go
+++ b/controllers/chat/websocket_controller_test.go
@@ -1,0 +1,204 @@
+package chat
+
+import (
+	"testing"
+	"net/http/httptest"
+	"net/http"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"github.com/posener/wstest"
+	"github.com/gorilla/websocket"
+	"github.com/aaronaaeng/chat.connor.fun/model"
+	"encoding/json"
+	"time"
+)
+
+type testHanlder struct {
+	e *echo.Echo
+	handler echo.HandlerFunc
+	err error
+}
+
+func (t *testHanlder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.err = t.handler(t.e.NewContext(r, w))
+}
+
+type testWsClient struct {
+	conn *websocket.Conn
+}
+
+func (c *testWsClient) write(message string) error {
+	jsonMessage := []byte(`{"text": "` + message + `"}`)
+	w, err := c.conn.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(jsonMessage)
+	if err != nil {
+		return err
+	}
+	return w.Close()
+}
+
+func (c *testWsClient) read() (model.ChatMessage, error) {
+	_, bMess, err := c.conn.ReadMessage()
+	if err != nil {
+		return model.ChatMessage{}, err
+	}
+	var messages []*model.ChatMessage
+	err = json.Unmarshal(bMess, &messages)
+	if err != nil {
+		return model.ChatMessage{}, err
+	}
+	return *messages[0], err
+}
+
+func TestHandleWebsocket_UpgradeWS(t *testing.T) {
+	e := echo.New()
+
+	hubMap := NewHubMap()
+
+	shouldBeTrue := false
+	handler := testHanlder{
+		e: e,
+		handler: func(c echo.Context) error {
+			shouldBeTrue = true
+			return HandleWebsocket(hubMap, true, c)
+		},
+	}
+
+	s := httptest.NewServer(&handler)
+
+	d := wstest.NewDialer(&handler, t.Log)
+
+	conn, resp, err := d.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode, "upgrade failed")
+
+	err = conn.WriteJSON("this won't do anything")
+	assert.NoError(t, err)
+
+	assert.NoError(t, handler.err)
+	assert.True(t, shouldBeTrue)
+}
+
+
+func TestHandleWebsocket_MultipleClients(t *testing.T) {
+	e := echo.New()
+
+	hubMap := NewHubMap()
+
+	shouldBeTrue := false
+	handler := testHanlder{
+		e: e,
+		handler: func(c echo.Context) error {
+			shouldBeTrue = true
+			return HandleWebsocket(hubMap, true, c)
+		},
+	}
+
+	s := httptest.NewServer(&handler)
+
+	dClient1 := wstest.NewDialer(&handler, t.Log)
+	dClient2 := wstest.NewDialer(&handler, t.Log)
+
+	client1Conn, resp, err := dClient1.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
+	assert.NoError(t, err)
+
+	assert.NoError(t, handler.err)
+	assert.True(t, shouldBeTrue)
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode, "upgrade failed")
+
+	client1 := testWsClient{conn: client1Conn}
+
+	client2Conn, resp, err := dClient2.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
+	assert.NoError(t, err)
+
+	assert.NoError(t, handler.err)
+	assert.True(t, shouldBeTrue)
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode, "upgrade failed")
+
+	client2 := testWsClient{conn: client2Conn}
+
+	defer func() {
+		client1.conn.Close()
+		client2.conn.Close()
+	}()
+
+	err = client1.write("hello")
+	assert.NoError(t, err)
+
+	client2.conn.SetReadDeadline(time.Now().Add(time.Duration(5 * time.Second)))
+	message, err := client2.read()
+	client2.conn.SetReadDeadline(time.Now().Add(time.Duration(5 * time.Second)))
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", message.Text)
+}
+
+func TestHandleWebsocket_IllegalMessage(t *testing.T) {
+	e := echo.New()
+
+	hubMap := NewHubMap()
+
+	shouldBeTrue := false
+	handler := testHanlder{
+		e: e,
+		handler: func(c echo.Context) error {
+			shouldBeTrue = true
+			return HandleWebsocket(hubMap, true, c)
+		},
+	}
+
+	s := httptest.NewServer(&handler)
+
+	d := wstest.NewDialer(&handler, t.Log)
+
+	conn, resp, err := d.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode, "upgrade failed")
+
+	err = conn.WriteJSON("this will cause me to get kicked by the server")
+	assert.NoError(t, err)
+
+	assert.NoError(t, handler.err)
+	assert.True(t, shouldBeTrue)
+
+	_, _, err = conn.ReadMessage()
+	assert.Error(t, err)
+
+}
+
+func TestHandleWebsocket_ReadOnly(t *testing.T) {
+	e := echo.New()
+
+	hubMap := NewHubMap()
+
+	shouldBeTrue := false
+	handler := testHanlder{
+		e: e,
+		handler: func(c echo.Context) error {
+			shouldBeTrue = true
+			return HandleWebsocket(hubMap, false, c)
+		},
+	}
+
+	s := httptest.NewServer(&handler)
+
+	d := wstest.NewDialer(&handler, t.Log)
+
+	conn, resp, err := d.Dial("ws://" + s.Listener.Addr().String() + "/ws", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode, "upgrade failed")
+
+	client := testWsClient{conn: conn}
+	err = client.write("foobar") //writing illegally should cause me to get kicked
+	assert.NoError(t, err)
+
+	_, err = client.read()
+	assert.Error(t, err)
+}

--- a/controllers/jwtmiddleware/authorization.go
+++ b/controllers/jwtmiddleware/authorization.go
@@ -19,7 +19,7 @@ func doAuthorization(next echo.HandlerFunc, claims *auth.Claims, c echo.Context)
 			c.JSON(http.StatusUnauthorized, invalidTokenResponse)
 		}
 		if claims.User.Username != "" { //this is very hacky
-			ac.Requestor = &claims.User
+			ac.SetRequestor(&claims.User)
 			userRoles, err := roles.Repo.GetUserRoles(claims.User.Id)
 			if err != nil {
 				return c.JSON(http.StatusInternalServerError, model.Response{
@@ -62,7 +62,7 @@ func doAuthorization(next echo.HandlerFunc, claims *auth.Claims, c echo.Context)
 	}
 
 	authorized, accessCode := isAuthorized(permissions, c.Request())
-	ac.Code = accessCode
+	ac.SetAccessCode(accessCode)
 	if authorized {
 		return next(ac)
 	} else {

--- a/controllers/jwtmiddleware/authorization_test.go
+++ b/controllers/jwtmiddleware/authorization_test.go
@@ -124,7 +124,7 @@ func TestDoAuthorization_WithAuth_Fail(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := context.AuthorizedContext{
+	c := &context.AuthorizedContextImpl{
 		Context: e.NewContext(req, rec),
 	}
 
@@ -156,15 +156,15 @@ func TestDoAuthorization_WithAuth(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := context.AuthorizedContext{
+	c := &context.AuthorizedContextImpl{
 		Context: e.NewContext(req, rec),
 	}
 
 	shouldBeTrue := false
 	failHandler := func(c echo.Context) error {
 		ac := c.(context.AuthorizedContext)
-		assert.True(t, ac.Code.CanCreate())
-		assert.NotNil(t, ac.Requestor)
+		assert.True(t, ac.GetAccessCode().CanCreate())
+		assert.NotNil(t, ac.GetRequestor())
 		shouldBeTrue = true
 		return nil
 	}
@@ -190,15 +190,15 @@ func TestDoAuthorization_NoAuth(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := context.AuthorizedContext{
+	c := &context.AuthorizedContextImpl{
 		Context: e.NewContext(req, rec),
 	}
 
 	shouldBeTrue := false
 	failHandler := func(c echo.Context) error {
 		ac := c.(context.AuthorizedContext)
-		assert.True(t, ac.Code.CanCreate())
-		assert.Nil(t, ac.Requestor)
+		assert.True(t, ac.GetAccessCode().CanCreate())
+		assert.Nil(t, ac.GetRequestor())
 		shouldBeTrue = true
 		return nil
 	}
@@ -219,7 +219,7 @@ func TestDoAuthorization_NoAuth_Fail(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := context.AuthorizedContext{
+	c := &context.AuthorizedContextImpl{
 		Context: e.NewContext(req, rec),
 	}
 

--- a/controllers/jwtmiddleware/authorization_test.go
+++ b/controllers/jwtmiddleware/authorization_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"github.com/aaronaaeng/chat.connor.fun/controllers/auth"
+	"github.com/aaronaaeng/chat.connor.fun/context"
 )
 const (
 	testDbHost = "localhost"
@@ -123,7 +124,9 @@ func TestDoAuthorization_WithAuth_Fail(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := e.NewContext(req, rec)
+	c := context.AuthorizedContext{
+		Context: e.NewContext(req, rec),
+	}
 
 	failHandler := func(c echo.Context) error {
 		assert.Fail(t, "Handler was called")
@@ -153,10 +156,15 @@ func TestDoAuthorization_WithAuth(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := e.NewContext(req, rec)
+	c := context.AuthorizedContext{
+		Context: e.NewContext(req, rec),
+	}
 
 	shouldBeTrue := false
 	failHandler := func(c echo.Context) error {
+		ac := c.(context.AuthorizedContext)
+		assert.True(t, ac.Code.CanCreate())
+		assert.NotNil(t, ac.Requestor)
 		shouldBeTrue = true
 		return nil
 	}
@@ -182,10 +190,15 @@ func TestDoAuthorization_NoAuth(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := e.NewContext(req, rec)
+	c := context.AuthorizedContext{
+		Context: e.NewContext(req, rec),
+	}
 
 	shouldBeTrue := false
 	failHandler := func(c echo.Context) error {
+		ac := c.(context.AuthorizedContext)
+		assert.True(t, ac.Code.CanCreate())
+		assert.Nil(t, ac.Requestor)
 		shouldBeTrue = true
 		return nil
 	}
@@ -206,7 +219,9 @@ func TestDoAuthorization_NoAuth_Fail(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 
-	c := e.NewContext(req, rec)
+	c := context.AuthorizedContext{
+		Context: e.NewContext(req, rec),
+	}
 
 	failHandler := func(c echo.Context) error {
 		assert.Fail(t, "Handler was called")

--- a/controllers/views_controller.go
+++ b/controllers/views_controller.go
@@ -14,3 +14,11 @@ func Index(c echo.Context) error {
 	}
 	return c.Render(http.StatusOK, "index.html", templateVars)
 }
+
+func WSTestView(c echo.Context) error {
+	templateVars := map[string]interface{} {
+		"publicUrl": "/web/public",
+		"srcUrl": "/web/src",
+	}
+	return c.Render(http.StatusOK, "wstest.html", templateVars)
+}

--- a/db/rooms/queries.go
+++ b/db/rooms/queries.go
@@ -1,0 +1,20 @@
+package rooms
+
+
+const (
+	createIfNotExistsRoomsQuery = `
+		CREATE TABLE IF NOT EXISTS rooms (
+			id SERIAL UNIQUE NOT NULL PRIMARY KEY,
+			name VARCHAR(20) UNIQUE NOT NULL
+		);
+	`
+
+	insertRoomQuery = `
+		INSERT INTO rooms (name) VALUES (:name);
+	`
+
+	selectRoomByNameQuery = `
+		SELECT * FROM rooms
+			WHERE name = :name;
+	`
+)

--- a/db/rooms/rooms_repository.go
+++ b/db/rooms/rooms_repository.go
@@ -1,0 +1,56 @@
+package rooms
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/aaronaaeng/chat.connor.fun/model"
+)
+
+type Repository struct {
+	db *sqlx.DB
+}
+
+var Repo Repository
+
+func Init(db *sqlx.DB) (Repository, error) {
+	_, err := db.Exec(createIfNotExistsRoomsQuery)
+	if err != nil {
+		return Repository{db: nil}, err
+	}
+	Repo = Repository{db: db}
+	return Repo, nil
+}
+
+
+func (r Repository) Create(room *model.ChatRoom) (*model.ChatRoom, error){
+	_, err := r.db.Exec(insertRoomQuery, &room)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := r.db.NamedQuery(selectRoomByNameQuery, &room)
+	if err != nil {
+		return nil, err
+	}
+
+	var insertedRoom model.ChatRoom
+	if rows.Next() {
+		rows.StructScan(&insertedRoom)
+	} else {
+		return nil, err //room not found
+	}
+
+	return &insertedRoom, nil
+}
+
+func (r Repository) GetByName(name string) (*model.ChatRoom, error) {
+	rows, err := r.db.NamedQuery(selectRoomByNameQuery, model.ChatRoom{Name: name})
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		var room model.ChatRoom
+		rows.StructScan(&room)
+		return &room, nil
+	}
+	return nil, nil //not found
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" xmlns="http://www.w3.org/1999/html">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -25,6 +25,36 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
+    <div id ="fuckingaround">
+        <script>
+            function sendMessage() {
+                console.log("sending message");
+                var message = {
+                    text: document.getElementById("textbox").value
+                };
+                document.getElementById("textbox").value = "";
+                exampleSocket.send(JSON.stringify(message))
+            }
+            var exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/foo/messages/ws");
+            exampleSocket.onmessage = function (ev) {
+                console.log("message sent")
+                var node = document.createElement("LI");                 // Create a <li> node
+                var textnode = document.createTextNode(ev.data);         // Create a text node
+                node.appendChild(textnode);                              // Append the text to <li>
+                document.getElementById("fuckingaround").appendChild(node);     // Append <li> to <ul> with id="myList"
+            }
+
+            var message = {
+                "text": "this si a message"
+            }
+            exampleSocket.onopen = function (ev) {
+                exampleSocket.send(JSON.stringify(message))
+            }
+        </script>
+        <input id="textbox" type="text"/>
+        <a href="javascript:void(0)" onclick="sendMessage()">Submit</a>
+
+    </div>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,32 +25,6 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <div id ="fuckingaround">
-        <script>
-            function sendMessage() {
-                console.log("sending message");
-                var message = {
-                    text: document.getElementById("textbox").value
-                };
-                document.getElementById("textbox").value = "";
-                exampleSocket.send(JSON.stringify(message))
-            }
-
-
-            var exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/foo/messages/ws");
-            exampleSocket.onmessage = function (ev) {
-                console.log("message sent");
-                var node = document.createElement("LI");                 // Create a <li> node
-                var textnode = document.createTextNode(ev.data);         // Create a text node
-                node.appendChild(textnode);                              // Append the text to <li>
-                document.getElementById("fuckingaround").appendChild(node);     // Append <li> to <ul> with id="myList"
-            };
-
-        </script>
-        <input id="textbox" type="text"/>
-        <a href="javascript:void(0)" onclick="sendMessage()">Submit</a>
-
-    </div>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -35,21 +35,17 @@
                 document.getElementById("textbox").value = "";
                 exampleSocket.send(JSON.stringify(message))
             }
+
+
             var exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/foo/messages/ws");
             exampleSocket.onmessage = function (ev) {
-                console.log("message sent")
+                console.log("message sent");
                 var node = document.createElement("LI");                 // Create a <li> node
                 var textnode = document.createTextNode(ev.data);         // Create a text node
                 node.appendChild(textnode);                              // Append the text to <li>
                 document.getElementById("fuckingaround").appendChild(node);     // Append <li> to <ul> with id="myList"
-            }
+            };
 
-            var message = {
-                "text": "this si a message"
-            }
-            exampleSocket.onopen = function (ev) {
-                exampleSocket.send(JSON.stringify(message))
-            }
         </script>
         <input id="textbox" type="text"/>
         <a href="javascript:void(0)" onclick="sendMessage()">Submit</a>

--- a/frontend/public/wstest.html
+++ b/frontend/public/wstest.html
@@ -29,7 +29,7 @@
         var exampleSocket;
         function connectToRoom() {
             room = document.getElementById("roombox").value;
-            exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/" + room +  "/messages/ws");
+            exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/" + room +  "/messages/write/ws", "thiswillbreak");
             exampleSocket.onmessage = addMessageToList
         }
 

--- a/frontend/public/wstest.html
+++ b/frontend/public/wstest.html
@@ -29,7 +29,15 @@
         var exampleSocket;
         function connectToRoom() {
             room = document.getElementById("roombox").value;
-            exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/" + room +  "/messages/write/ws", "thiswillbreak");
+            token = null;
+            if (document.getElementById("tokenbox").value != "") {
+                token = document.getElementById("tokenbox").value;
+            }
+            if (token == null) {
+                exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/" + room +  "/messages/ws");
+            } else {
+                exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/" + room +  "/messages/ws", token);
+            }
             exampleSocket.onmessage = addMessageToList
         }
 
@@ -39,6 +47,7 @@
     <a href="javascript:void(0)" onclick="sendMessage()">Submit</a>
     <input id="roombox" type="text"/>
     <a href="javascript:void(0)" onclick="connectToRoom()">Connect</a>
+    <input id="tokenbox" type="text"/>
 
 </div>
 </body>

--- a/frontend/public/wstest.html
+++ b/frontend/public/wstest.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WS Test</title>
+</head>
+<body>
+
+<div id ="fuckingaround">
+    <script>
+        function sendMessage() {
+            console.log("sending message");
+            var message = {
+                text: document.getElementById("textbox").value
+            };
+            document.getElementById("textbox").value = "";
+            exampleSocket.send(JSON.stringify(message))
+        }
+
+
+        var exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/foo/messages/ws");
+        exampleSocket.onmessage = function (ev) {
+            console.log("message sent");
+            var node = document.createElement("LI");                 // Create a <li> node
+            var textnode = document.createTextNode(ev.data);         // Create a text node
+            node.appendChild(textnode);                              // Append the text to <li>
+            document.getElementById("fuckingaround").appendChild(node);     // Append <li> to <ul> with id="myList"
+        };
+
+    </script>
+    <input id="textbox" type="text"/>
+    <a href="javascript:void(0)" onclick="sendMessage()">Submit</a>
+
+</div>
+</body>
+</html>

--- a/frontend/public/wstest.html
+++ b/frontend/public/wstest.html
@@ -16,20 +16,29 @@
             document.getElementById("textbox").value = "";
             exampleSocket.send(JSON.stringify(message))
         }
-
-
-        var exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/foo/messages/ws");
-        exampleSocket.onmessage = function (ev) {
+        
+        function addMessageToList(ev) {
             console.log("message sent");
-            var node = document.createElement("LI");                 // Create a <li> node
-            var textnode = document.createTextNode(ev.data);         // Create a text node
-            node.appendChild(textnode);                              // Append the text to <li>
-            document.getElementById("fuckingaround").appendChild(node);     // Append <li> to <ul> with id="myList"
-        };
+            var node = document.createElement("LI");
+            var textnode = document.createTextNode(ev.data);
+            node.appendChild(textnode);
+            document.getElementById("fuckingaround").appendChild(node);
+        }
+
+
+        var exampleSocket;
+        function connectToRoom() {
+            room = document.getElementById("roombox").value;
+            exampleSocket = new WebSocket("ws://localhost:4000/api/v1/rooms/" + room +  "/messages/ws");
+            exampleSocket.onmessage = addMessageToList
+        }
+
 
     </script>
     <input id="textbox" type="text"/>
     <a href="javascript:void(0)" onclick="sendMessage()">Submit</a>
+    <input id="roombox" type="text"/>
+    <a href="javascript:void(0)" onclick="connectToRoom()">Connect</a>
 
 </div>
 </body>

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func addMiddlewares(e *echo.Echo) {
 	//this must be added first
 	e.Use(func(h echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			cc := &context.AuthorizedContext{Context: c}
+			cc := &context.AuthorizedContextImpl{Context: c}
 			return h(cc)
 		}
 	})

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 	}
 	e.Renderer = t
 	e.GET("/", controllers.Index)
+	e.GET("/wstest", controllers.WSTestView)
 
 	e.GET("/api/v1/rooms/:room/messages/ws", func(c echo.Context) error {
 		return chat.HandleWebsocket(hubMap, true, c)

--- a/main.go
+++ b/main.go
@@ -17,12 +17,14 @@ import (
 	"io/ioutil"
 	"github.com/aaronaaeng/chat.connor.fun/controllers/jwtmiddleware"
 	"strings"
+	"github.com/aaronaaeng/chat.connor.fun/controllers/chat"
 )
 
 
 func createApiRoutes(e *echo.Echo) {
 	e.POST("/api/v1/users", controllers.CreateUser)
 	e.POST("/api/v1/login", controllers.LoginUser)
+
 }
 
 func addMiddlewares(e *echo.Echo) {
@@ -66,6 +68,8 @@ func main() {
 		e.Logger.Fatal(fmt.Errorf("error creating roles data"))
 	}
 
+	hubMap := chat.NewHubMap()
+
 	initDatabaseRepositories()
 
 
@@ -76,6 +80,15 @@ func main() {
 	}
 	e.Renderer = t
 	e.GET("/", controllers.Index)
+
+	e.GET("/api/v1/rooms/:room/messages/ws", func(c echo.Context) error {
+		return chat.HandleWebsocket(hubMap, false, c)
+	})
+
+	e.POST("/api/v1/rooms/:room/messages/ws", func(c echo.Context) error {
+		return chat.HandleWebsocket(hubMap, true, c)
+	})
+
 
 	createApiRoutes(e)
 	e.Logger.Fatal(e.Start(":4000"))

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	e.GET("/", controllers.Index)
 
 	e.GET("/api/v1/rooms/:room/messages/ws", func(c echo.Context) error {
-		return chat.HandleWebsocket(hubMap, false, c)
+		return chat.HandleWebsocket(hubMap, true, c)
 	})
 
 	e.POST("/api/v1/rooms/:room/messages/ws", func(c echo.Context) error {

--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ func addMiddlewares(e *echo.Echo) {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.Use(jwtmiddleware.JwtAuth(func(c echo.Context) bool {
-		return strings.HasPrefix(c.Path(), "/web") //skip static assets
+		return strings.HasPrefix(c.Path(), "/web") ||
+				strings.HasPrefix(c.Path(), "/favicon.ico")//skip static assets
 	}))
 }
 

--- a/model/chat_room.go
+++ b/model/chat_room.go
@@ -1,0 +1,8 @@
+package model
+
+type ChatRoom struct {
+	Id int64 `json:"id"`
+	Name string `json:"name"`
+	Members []*User `json:"members"`
+	//maybe geolocation data
+}

--- a/model/message.go
+++ b/model/message.go
@@ -1,0 +1,10 @@
+package model
+
+
+type ChatMessage struct {
+	Creator User `json:"sender,omitempty"`
+	Text string `json:"text"`
+	CreateDate int64 `json:"createTime"`
+}
+
+

--- a/model/permission.go
+++ b/model/permission.go
@@ -140,8 +140,25 @@ func (p Permission) DoesMethodMatch(path string) bool {
 
 }
 
+func (p Permission) DoesPathMatch(path string) bool {
+	if path == "/" && path == p.Path {
+		return true
+	}
+	splitPath := strings.Split(path, "/")
+	splitPermission := strings.Split(p.Path, "/")
+	if len(splitPath) == len(splitPermission) {
+		for i := 0; i < len(splitPath); i++ {
+			if splitPermission[i] != "*" && splitPath[i] != splitPermission[i] {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 func (p Permission) IsPermitted(method string, path string) bool {
-	pathMatch := path == p.Path
+	pathMatch := p.DoesPathMatch(path)
 	methodMatch := p.DoesMethodMatch(method)
 	return pathMatch && methodMatch
 }

--- a/model/permission.go
+++ b/model/permission.go
@@ -12,21 +12,41 @@ const actionDelete = 0xF000
 
 type AccessCode int
 
+func (ac AccessCode) canDoAction(action AccessCode) bool {
+	return (ac & action) != 0
+}
+
+func (ac AccessCode) CanCreate() bool {
+	return ac.canDoAction(actionCreate)
+}
+
+func (ac AccessCode) CanRead() bool {
+	return ac.canDoAction(actionRead)
+}
+
+func (ac AccessCode) CanUpdate() bool {
+	return ac.canDoAction(actionUpdate)
+}
+
+func (ac AccessCode) CanDelete() bool {
+	return ac.canDoAction(actionDelete)
+}
+
 type Permission struct {
 	Path string
-	code AccessCode
+	Code AccessCode
 }
 
-func (p Permission) setAction(action AccessCode) {
-	p.code |= action
+func (p *Permission) setAction(action AccessCode) {
+	p.Code |= action
 }
 
-func (p Permission) setNotAction(action AccessCode)  {
-	p.code &= ^action
+func (p *Permission) setNotAction(action AccessCode)  {
+	p.Code &= ^action
 }
 
 func (p Permission) canDoAction(action AccessCode) bool {
-	return (p.code & action) != 0
+	return p.Code.canDoAction(action)
 }
 
 func (p Permission) CanCreate() bool {
@@ -45,35 +65,35 @@ func (p Permission) CanDelete() bool {
 	return p.canDoAction(actionDelete)
 }
 
-func (p Permission) SetCreate() {
+func (p *Permission) SetCreate() {
 	p.setAction(actionCreate)
 }
 
-func (p Permission) SetUpdate()  {
+func (p *Permission) SetUpdate()  {
 	p.setAction(actionUpdate)
 }
 
-func (p Permission) SetRead()  {
+func (p *Permission) SetRead()  {
 	p.setAction(actionRead)
 }
 
-func (p Permission) SetDelete()  {
+func (p *Permission) SetDelete()  {
 	p.setAction(actionDelete)
 }
 
-func (p Permission) SetNotCreate() {
+func (p *Permission) SetNotCreate() {
 	p.setNotAction(actionCreate)
 }
 
-func (p Permission) SetNotUpdate()  {
+func (p *Permission) SetNotUpdate()  {
 	p.setNotAction(actionUpdate)
 }
 
-func (p Permission) SetNotRead()  {
+func (p *Permission) SetNotRead()  {
 	p.setNotAction(actionRead)
 }
 
-func (p Permission) SetNotDelete()  {
+func (p *Permission) SetNotDelete()  {
 	p.setNotAction(actionDelete)
 }
 
@@ -94,7 +114,7 @@ func (p Permission) generateVerbsStr() string {
 	return verbs
 }
 
-func generateVerbCode(verbs string) AccessCode {
+func GenerateVerbCode(verbs string) AccessCode {
 	var code AccessCode
 	if strings.Contains(verbs, "c") {
 		code |= actionCreate
@@ -128,7 +148,7 @@ func (p *Permission) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	p.Path = perm["path"]
-	p.code = generateVerbCode(perm["verbs"])
+	p.Code = GenerateVerbCode(perm["verbs"])
 	return nil
 }
 
@@ -164,5 +184,5 @@ func (p Permission) IsPermitted(method string, path string) bool {
 }
 
 func (p Permission) String() string {
-	return "Permission: [" + p.Path + ", " + string(p.code) + "]"
+	return "Permission: [" + p.Path + ", " + string(p.Code) + "]"
 }

--- a/model/permission_set_test.go
+++ b/model/permission_set_test.go
@@ -14,10 +14,10 @@ func TestNewPermissionSet(t *testing.T) {
 func TestPermissionSet_Add(t *testing.T) {
 	ps := NewPermissionSet()
 
-	p1 := Permission{Path: "/foo/bar", code: 0x00F0}
-	p2 := Permission{Path: "/foo/bar/1", code: 0x00FF}
-	p3 := Permission{Path: "/foo/bar/2", code: 0x0FF0}
-	p4 := Permission{Path: "/foo/bar/3", code: 0xF0F0}
+	p1 := Permission{Path: "/foo/bar", Code: 0x00F0}
+	p2 := Permission{Path: "/foo/bar/1", Code: 0x00FF}
+	p3 := Permission{Path: "/foo/bar/2", Code: 0x0FF0}
+	p4 := Permission{Path: "/foo/bar/3", Code: 0xF0F0}
 
 	ps.Add(p1)
 
@@ -38,8 +38,8 @@ func TestPermissionSet_Add(t *testing.T) {
 func TestPermissionSet_Contains(t *testing.T) {
 	ps := NewPermissionSet()
 
-	p1 := Permission{Path: "/foo/bar", code: 0x00F0}
-	p2 := Permission{Path: "/foo/bar/1", code: 0x00FF}
+	p1 := Permission{Path: "/foo/bar", Code: 0x00F0}
+	p2 := Permission{Path: "/foo/bar/1", Code: 0x00FF}
 
 	assert.False(t, ps.Contains(p1))
 
@@ -52,10 +52,10 @@ func TestPermissionSet_Contains(t *testing.T) {
 func TestPermissionSet_Permissions(t *testing.T) {
 	ps := NewPermissionSet()
 
-	p1 := Permission{Path: "/foo/bar", code: 0x00F0}
-	p2 := Permission{Path: "/foo/bar/1", code: 0x00FF}
-	p3 := Permission{Path: "/foo/bar/2", code: 0x0FF0}
-	p4 := Permission{Path: "/foo/bar/3", code: 0xF0F0}
+	p1 := Permission{Path: "/foo/bar", Code: 0x00F0}
+	p2 := Permission{Path: "/foo/bar/1", Code: 0x00FF}
+	p3 := Permission{Path: "/foo/bar/2", Code: 0x0FF0}
+	p4 := Permission{Path: "/foo/bar/3", Code: 0xF0F0}
 
 	ps.Add(p1, p2, p3, p4)
 

--- a/model/permission_test.go
+++ b/model/permission_test.go
@@ -34,3 +34,22 @@ func TestPermissionJSONUnmarshal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, pActual, p)
 }
+
+func TestPermission_IsPermitted_SimplePath(t *testing.T) {
+	p := Permission{Path: "/foo/bar/foo/bar", code: actionRead | actionDelete}
+
+	assert.True(t, p.IsPermitted("GET", "/foo/bar/foo/bar"), "failed same method and path")
+	assert.True(t, p.IsPermitted("DELETE", "/foo/bar/foo/bar"), "failed same method and path")
+	assert.False(t, p.IsPermitted("GET", "/foo/bar/foo/baz"), "failed same method and wrong path")
+
+	assert.False(t, p.IsPermitted("POST", "/foo/bar/foo/bar"), "failed wrong method same path")
+}
+
+func TestPermission_IsPermitted_(t *testing.T) {
+	p := Permission{Path: "/foo/*/foo/bar", code: actionRead}
+
+	assert.True(t, p.IsPermitted("GET", "/foo/1/foo/bar"))
+	assert.True(t, p.IsPermitted("GET", "/foo/2/foo/bar"))
+
+	assert.False(t, p.IsPermitted("GET", "/foo/2/foo/abcd"))
+}

--- a/model/permission_test.go
+++ b/model/permission_test.go
@@ -13,7 +13,7 @@ const (
 func TestPermissionJSONMarshal(t *testing.T) {
 	p := Permission{
 		Path: "a/b/foo/bar",
-		code: 0xFFFF,
+		Code: 0xFFFF,
 	}
 
 	jsonP, err := json.Marshal(p)
@@ -28,7 +28,7 @@ func TestPermissionJSONUnmarshal(t *testing.T) {
 
 	pActual := Permission{
 		Path: "a/b/foo/bar",
-		code: 0xFFFF,
+		Code: 0xFFFF,
 	}
 
 	assert.NoError(t, err)
@@ -36,7 +36,7 @@ func TestPermissionJSONUnmarshal(t *testing.T) {
 }
 
 func TestPermission_IsPermitted_SimplePath(t *testing.T) {
-	p := Permission{Path: "/foo/bar/foo/bar", code: actionRead | actionDelete}
+	p := Permission{Path: "/foo/bar/foo/bar", Code: actionRead | actionDelete}
 
 	assert.True(t, p.IsPermitted("GET", "/foo/bar/foo/bar"), "failed same method and path")
 	assert.True(t, p.IsPermitted("DELETE", "/foo/bar/foo/bar"), "failed same method and path")
@@ -46,7 +46,7 @@ func TestPermission_IsPermitted_SimplePath(t *testing.T) {
 }
 
 func TestPermission_IsPermitted_(t *testing.T) {
-	p := Permission{Path: "/foo/*/foo/bar", code: actionRead}
+	p := Permission{Path: "/foo/*/foo/bar", Code: actionRead}
 
 	assert.True(t, p.IsPermitted("GET", "/foo/1/foo/bar"))
 	assert.True(t, p.IsPermitted("GET", "/foo/2/foo/bar"))


### PR DESCRIPTION
This fixes like a million bugs with the IsPermitted function. Makes some sketchy changes to make unit testing easier too.

Allows handlers to access some auth data like the access code and the user associated with the request. This is useful for saving db transactions and conditional behavior (specifically for websockets which have a terrible standard)

Adds the chat endpoint and a page at `/wstest` that lets you mess with the chat endpoint.