### PR TITLE
Add relative timestamps to messages 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "dependencies": {
     "axios": "^0.17.1",
+    "custom-react-scripts": "0.2.1",
+    "intl-relativeformat": "^2.1.0",
     "mobx": "^3.4.1",
     "mobx-react": "^4.3.5",
     "promise.prototype.finally": "^3.1.0",
-    "custom-react-scripts": "0.2.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2"

--- a/frontend/src/components/Messages/Message/index.css
+++ b/frontend/src/components/Messages/Message/index.css
@@ -3,10 +3,10 @@
     height: auto;
     max-height: 100px;
     grid-column-gap: 15px;
-    grid-template-columns: 40px 1fr;
+    grid-template-columns: 40px auto 1fr;
     grid-template-rows: 20px 1fr;
-    grid-template-areas: "avatar username"
-                         "avatar message";
+    grid-template-areas: "avatar username timestamp"
+                         "avatar message message";
     margin: 7.5px auto;
 }
 
@@ -22,8 +22,17 @@
 
 .Message .handle {
     grid-area: username;
+    line-height: 20px;
     font-weight: 700;
     font-size: 0.8em;
+}
+
+.Message .timestamp {
+    grid-area: timestamp;
+    line-height: 20px;
+    font-style: italic;
+    font-size: 0.7em;
+    color: #666;
 }
 
 .Message .content {

--- a/frontend/src/components/Messages/Message/index.js
+++ b/frontend/src/components/Messages/Message/index.js
@@ -1,14 +1,18 @@
 import React, { Component } from 'react'
 import './index.css'
+import IntlRelativeFormat from 'intl-relativeformat'
+// require('intl-relativeformat/dist/locale-data/en.js')
 
 class Message extends Component {
     render() {
+        let rf = new IntlRelativeFormat('en-US')
         return (
             <div className="Message">
                 <div className="avatar" >
                     <img className="concave-small" src={"https://sigil.cupcake.io/" + this.props.sender + ".png?inverted=1"} alt={this.props.sender} />
                 </div>
                 <span className="handle">{this.props.sender}</span>
+                <span className="timestamp">{rf.format(this.props.date)}</span>
                 <span className="content">{this.props.message}</span>
             </div>
         )

--- a/frontend/src/components/Messages/index.js
+++ b/frontend/src/components/Messages/index.js
@@ -13,7 +13,7 @@ class Messages extends Component {
             <div className="Messages">
                 {
                     this.props.messages.map((obj) => (
-                        <Message key={obj.id} message={obj.text} sender={obj.sender.username}/>
+                        <Message key={obj.id} date={new Date(obj.createTime * 1000)} message={obj.text} sender={obj.sender.username}/>
                     ))
                 }
             </div>


### PR DESCRIPTION
This PR resolves #41 by adding a timestamp display to Message components. In the future we will want to consider refreshing the displayed time every so often, but for now it just updates on a new message/reload.